### PR TITLE
[noticket] Fix broken ninja-rmm devcontainer build

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -31,7 +31,8 @@
 			"version": "latest"
 		},
 		"ghcr.io/devcontainers/features/java:1": {
-			"version": "lts",
+			"version": "21",
+			"jdkDistro": "ms",
 			"installMaven": true,
 			"installGradle": true
 		}


### PR DESCRIPTION
## Project Management

Linear Ticket: N/A

## Description

Fixes the java devcontainer version definition, which was breaking the build.

## Testing Plan

- [x] Devcontainer builds successfully