### PR TITLE
[TRE-3018]: Add missing API enum values to the spec during SDK generation

### DIFF
--- a/scripts/add_missing_enum_values.py
+++ b/scripts/add_missing_enum_values.py
@@ -1,0 +1,59 @@
+import argparse
+from pathlib import Path
+from ruamel.yaml import YAML
+
+# values Ninjarmm API returns that are not in the OpenAPI spec
+MISSING_ENUM_VALUES = {
+    "nodeClass": ["AOSP"],
+}
+
+
+def add_missing_enum_values(openapi_path):
+    yaml = YAML()
+    yaml.preserve_quotes = True
+    yaml.allow_duplicate_keys = False
+    yaml.default_flow_style = False
+
+    with open(openapi_path, "r") as f:
+        data = yaml.load(f)
+
+    added = 0
+
+    def walk(node, prop_name):
+        nonlocal added
+        if isinstance(node, dict):
+            if "enum" in node and prop_name in MISSING_ENUM_VALUES:
+                for value in MISSING_ENUM_VALUES[prop_name]:
+                    if value not in node["enum"]:
+                        node["enum"].append(value)
+                        added += 1
+            for key, value in node.items():
+                # An array's `items` schema carries the parent property's name.
+                walk(value, prop_name if key == "items" else key)
+        elif isinstance(node, list):
+            for item in node:
+                walk(item, prop_name)
+
+    walk(data, None)
+
+    with open(openapi_path, "w") as f:
+        yaml.dump(data, f)
+    return added
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Add missing enum values to OpenAPI spec"
+    )
+    parser.add_argument(
+        "--spec",
+        default="openapi_spec.yaml",
+        type=Path,
+        help="Path to the OpenAPI spec to patch",
+    )
+
+    args = parser.parse_args()
+    openapi_path = args.spec
+
+    count = add_missing_enum_values(openapi_path)
+    print(f"Added {count} missing enum value(s) to {openapi_path}")

--- a/scripts/fix_openapi_spec.py
+++ b/scripts/fix_openapi_spec.py
@@ -1,4 +1,5 @@
-import sys
+import argparse
+from pathlib import Path
 from ruamel.yaml import YAML
 import re
 
@@ -50,6 +51,17 @@ def add_200_responses(openapi_path):
 
 
 if __name__ == "__main__":
-    openapi_path = sys.argv[1] if len(sys.argv) > 1 else "openapi_spec.yaml"
+    parser = argparse.ArgumentParser(
+        description="Add missing 200 responses to OpenAPI spec"
+    )
+    parser.add_argument(
+        "--spec",
+        default="openapi_spec.yaml",
+        type=Path,
+        help="Path to the OpenAPI spec to patch",
+    )
+
+    args = parser.parse_args()
+    openapi_path = args.spec
     add_200_responses(openapi_path)
     print(f"Added missing 200 responses to {openapi_path}")

--- a/scripts/generate_python_sdk.sh
+++ b/scripts/generate_python_sdk.sh
@@ -3,6 +3,9 @@
 # Fixes the openapi_spec.yaml file to include response types
 uv run python scripts/fix_openapi_spec.py
 
+# Inserts missing enum values into the openapi_spec.yaml file
+uv run python scripts/add_missing_enum_values.py
+
 # Gets the necessary models for the APIs we want to generate
 MODELS=$(uv run python scripts/get_necessary_models.py --spec openapi_spec.yaml --apis system,management,devices,queries)
 


### PR DESCRIPTION
## Project Management

https://linear.app/treeline/issue/TRE-3018

## Description

NinjaOne's (beta) API returns new enum values from the sandbox endpoint before
they appear in its published OpenAPI spec, so the generated client's strict
validators reject them and abort the whole extract (a `nodeClass` of `AOSP`
triggered this on the dev sync). Rather than dropping validation, this adds a
pre-generation transform that injects known API-returned-but-unspecced values
into the spec, keyed by property. Validation stays intact — a genuinely new
value still surfaces as a dev/sandbox alert we can add deliberately before it
reaches prod (dev and prod hit different Ninja endpoints, and the sandbox gets
changes first) — while known values pass. Applied as a transform, not a raw
spec edit, so additions survive a fresh spec re-download.

## Testing Plan

Logic only — no client regeneration here; generated output is in the stacked
PR #19. Verified the transform adds `AOSP` to every `nodeClass` enum in the
spec and leaves other enums (including `nodeClassDefault`) untouched.
